### PR TITLE
Orchestration: topological step order and post-plan allowed_tools lint

### DIFF
--- a/agent/orchestration_plan_lint.go
+++ b/agent/orchestration_plan_lint.go
@@ -1,0 +1,196 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"custom-agent/agent/planning"
+	"custom-agent/tools"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// toolAddition is one LLM-suggested batch of tools for a step.
+type toolAddition struct {
+	StepID string   `json:"step_id"`
+	Tools  []string `json:"tools"`
+}
+
+type orchestrationPlanLintResponse struct {
+	Additions []toolAddition `json:"additions"`
+}
+
+type orchestrationPlanLintPayload struct {
+	Goal  string                      `json:"goal"`
+	Steps []orchestrationPlanLintStep `json:"steps"`
+}
+
+type orchestrationPlanLintStep struct {
+	ID           string   `json:"id"`
+	Description  string   `json:"description"`
+	AllowedTools []string `json:"allowed_tools"`
+	DependsOn    []string `json:"depends_on"`
+	Risk         string   `json:"risk"`
+}
+
+func orchestrationPlanForLintJSON(plan *planning.OrchestrationPlan) ([]byte, error) {
+	if plan == nil {
+		return nil, fmt.Errorf("plan is nil")
+	}
+	payload := orchestrationPlanLintPayload{
+		Goal:  plan.Goal,
+		Steps: make([]orchestrationPlanLintStep, 0, len(plan.Steps)),
+	}
+	for _, s := range plan.Steps {
+		payload.Steps = append(payload.Steps, orchestrationPlanLintStep{
+			ID:           s.ID,
+			Description:  s.Description,
+			AllowedTools: append([]string(nil), s.AllowedTools...),
+			DependsOn:    append([]string(nil), s.DependsOn...),
+			Risk:         string(s.Risk),
+		})
+	}
+	return json.Marshal(payload)
+}
+
+func cloneOrchestrationPlan(p *planning.OrchestrationPlan) *planning.OrchestrationPlan {
+	if p == nil {
+		return nil
+	}
+	out := &planning.OrchestrationPlan{
+		Goal:  p.Goal,
+		Steps: make([]planning.OrchestrationStep, len(p.Steps)),
+	}
+	for i, s := range p.Steps {
+		out.Steps[i] = planning.OrchestrationStep{
+			ID:           s.ID,
+			Description:  s.Description,
+			Risk:         s.Risk,
+			AllowedTools: append([]string(nil), s.AllowedTools...),
+			DependsOn:    append([]string(nil), s.DependsOn...),
+		}
+	}
+	return out
+}
+
+// mergeOrchestrationToolAdditions appends registered, non-duplicate tools from additions onto
+// matching steps. Unknown tools, spawn_subagents, and wallet_* tools when walletConfigured is false are skipped.
+func mergeOrchestrationToolAdditions(plan *planning.OrchestrationPlan, additions []toolAddition, walletConfigured bool) (*planning.OrchestrationPlan, error) {
+	if plan == nil {
+		return nil, fmt.Errorf("plan is nil")
+	}
+	stepIdx := make(map[string]int, len(plan.Steps))
+	for i, s := range plan.Steps {
+		stepIdx[s.ID] = i
+	}
+	for _, add := range additions {
+		idx, ok := stepIdx[add.StepID]
+		if !ok {
+			continue
+		}
+		seen := make(map[string]bool, len(plan.Steps[idx].AllowedTools))
+		for _, existing := range plan.Steps[idx].AllowedTools {
+			seen[strings.TrimSpace(existing)] = true
+		}
+		for _, raw := range add.Tools {
+			name := strings.TrimSpace(raw)
+			if name == "" || name == "spawn_subagents" {
+				continue
+			}
+			if !tools.IsRegisteredTool(name) {
+				continue
+			}
+			if strings.HasPrefix(name, "wallet_") && !walletConfigured {
+				continue
+			}
+			if seen[name] {
+				continue
+			}
+			plan.Steps[idx].AllowedTools = append(plan.Steps[idx].AllowedTools, name)
+			seen[name] = true
+		}
+	}
+	return plan, nil
+}
+
+// lintOrchestrationPlanAllowedTools asks a small model for missing allowed_tools implied by each step,
+// merges suggestions when validation passes, and returns the same plan pointer (unchanged on error or if nothing valid).
+func (a *Agent) lintOrchestrationPlanAllowedTools(ctx context.Context, plan *planning.OrchestrationPlan, userText string, contextPrefix []openai.ChatCompletionMessage) *planning.OrchestrationPlan {
+	if plan == nil {
+		return plan
+	}
+	mode := strings.ToLower(strings.TrimSpace(a.orchestration.Mode))
+	if mode == "" || mode == planning.OrchestrationModeOff {
+		return plan
+	}
+	if a.tools == nil {
+		return plan
+	}
+
+	sys := `You review an orchestration plan. Output ONLY valid JSON, no markdown.
+Shape: {"additions":[{"step_id":"s1","tools":["tool_name",...]}]}
+
+Rules:
+- Suggest ONLY tools that are MISSING from that step's allowed_tools but are clearly implied by the step description/goal for that step.
+- Every tool name MUST be a valid registered tool name for this assistant. Never invent names.
+- Never include "spawn_subagents".
+- If a suggested tool is already in allowed_tools for that step, omit it.
+- If nothing is missing, return {"additions":[]}.`
+
+	planJSON, err := orchestrationPlanForLintJSON(plan)
+	if err != nil {
+		log.Printf("[orchestration] plan lint: marshal plan: %v", err)
+		return plan
+	}
+	userBody := "User request:\n" + userText + "\n\nPlan JSON:\n" + string(planJSON)
+
+	msgs := make([]openai.ChatCompletionMessage, 0, 2+len(contextPrefix))
+	msgs = append(msgs, openai.ChatCompletionMessage{Role: openai.ChatMessageRoleSystem, Content: sys})
+	msgs = append(msgs, contextPrefix...)
+	msgs = append(msgs, openai.ChatCompletionMessage{Role: openai.ChatMessageRoleUser, Content: userBody})
+
+	req := openai.ChatCompletionRequest{
+		Model:    subagentModelForIndex(0),
+		Messages: msgs,
+	}
+	t0 := time.Now()
+	resp, err := a.client.CreateChatCompletion(ctx, req)
+	a.recordLLMRound(ctx, "orchestration_plan_lint", 0, req, resp, err, t0)
+	if err != nil {
+		log.Printf("[orchestration] plan lint LLM: %v", err)
+		return plan
+	}
+	if len(resp.Choices) == 0 {
+		return plan
+	}
+	raw := extractJSONObject(strings.TrimSpace(resp.Choices[0].Message.Content))
+	var parsed orchestrationPlanLintResponse
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		log.Printf("[orchestration] plan lint parse: %v", err)
+		return plan
+	}
+
+	trial := cloneOrchestrationPlan(plan)
+	walletOK := a.tools.Wallet != nil
+	if _, err := mergeOrchestrationToolAdditions(trial, parsed.Additions, walletOK); err != nil {
+		log.Printf("[orchestration] plan lint merge: %v", err)
+		return plan
+	}
+	if err := planning.ValidateOrchestrationPlan(trial, tools.IsRegisteredTool); err != nil {
+		log.Printf("[orchestration] plan lint validate plan: %v", err)
+		return plan
+	}
+	if err := planning.ValidateOrchestrationPlanPolicy(trial, a.tools); err != nil {
+		log.Printf("[orchestration] plan lint validate policy: %v", err)
+		return plan
+	}
+
+	for i := range plan.Steps {
+		plan.Steps[i].AllowedTools = append([]string(nil), trial.Steps[i].AllowedTools...)
+	}
+	return plan
+}

--- a/agent/orchestration_plan_lint_test.go
+++ b/agent/orchestration_plan_lint_test.go
@@ -1,0 +1,120 @@
+package agent
+
+import (
+	"testing"
+
+	"custom-agent/agent/planning"
+	"custom-agent/tools"
+)
+
+func TestMergeOrchestrationToolAdditions(t *testing.T) {
+	basePlan := func() *planning.OrchestrationPlan {
+		return &planning.OrchestrationPlan{
+			Goal: "g",
+			Steps: []planning.OrchestrationStep{
+				{
+					ID:           "s1",
+					Description:  "search",
+					AllowedTools: []string{"web_search"},
+					Risk:         planning.StepRiskReadOnly,
+				},
+				{
+					ID:           "s2",
+					Description:  "read",
+					AllowedTools: []string{"read_file"},
+					Risk:         planning.StepRiskReadOnly,
+				},
+			},
+		}
+	}
+
+	t.Run("duplicates ignored", func(t *testing.T) {
+		p := basePlan()
+		got, err := mergeOrchestrationToolAdditions(p, []toolAddition{
+			{StepID: "s1", Tools: []string{"web_search", " web_search "}},
+		}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got.Steps[0].AllowedTools) != 1 || got.Steps[0].AllowedTools[0] != "web_search" {
+			t.Fatalf("s1 tools: %v", got.Steps[0].AllowedTools)
+		}
+	})
+
+	t.Run("unknown tool skipped", func(t *testing.T) {
+		p := basePlan()
+		got, err := mergeOrchestrationToolAdditions(p, []toolAddition{
+			{StepID: "s1", Tools: []string{"not_a_registered_tool_xyz", "read_memory"}},
+		}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{"web_search", "read_memory"}
+		if len(got.Steps[0].AllowedTools) != len(want) {
+			t.Fatalf("got %v want %v", got.Steps[0].AllowedTools, want)
+		}
+		for i, w := range want {
+			if got.Steps[0].AllowedTools[i] != w {
+				t.Fatalf("got %v want %v", got.Steps[0].AllowedTools, want)
+			}
+		}
+	})
+
+	t.Run("wallet tool skipped without wallet", func(t *testing.T) {
+		p := basePlan()
+		got, err := mergeOrchestrationToolAdditions(p, []toolAddition{
+			{StepID: "s1", Tools: []string{"wallet_get_balance", "read_memory"}},
+		}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := []string{"web_search", "read_memory"}
+		if len(got.Steps[0].AllowedTools) != len(want) {
+			t.Fatalf("got %v want %v", got.Steps[0].AllowedTools, want)
+		}
+		for i, w := range want {
+			if got.Steps[0].AllowedTools[i] != w {
+				t.Fatalf("got %v want %v", got.Steps[0].AllowedTools, want)
+			}
+		}
+	})
+
+	t.Run("successful merge validates", func(t *testing.T) {
+		p := basePlan()
+		got, err := mergeOrchestrationToolAdditions(p, []toolAddition{
+			{StepID: "s2", Tools: []string{"read_memory", "list_skills"}},
+		}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := planning.ValidateOrchestrationPlan(got, tools.IsRegisteredTool); err != nil {
+			t.Fatal(err)
+		}
+		toolsSet := map[string]bool{}
+		for _, n := range got.Steps[1].AllowedTools {
+			toolsSet[n] = true
+		}
+		if !toolsSet["read_file"] || !toolsSet["read_memory"] || !toolsSet["list_skills"] {
+			t.Fatalf("s2 tools: %v", got.Steps[1].AllowedTools)
+		}
+	})
+
+	t.Run("spawn_subagents skipped", func(t *testing.T) {
+		p := basePlan()
+		got, err := mergeOrchestrationToolAdditions(p, []toolAddition{
+			{StepID: "s1", Tools: []string{"spawn_subagents", "read_memory"}},
+		}, false)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got.Steps[0].AllowedTools) != 2 {
+			t.Fatalf("got %v", got.Steps[0].AllowedTools)
+		}
+	})
+
+	t.Run("nil plan errors", func(t *testing.T) {
+		if _, err := mergeOrchestrationToolAdditions(nil, nil, true); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}

--- a/agent/orchestration_run.go
+++ b/agent/orchestration_run.go
@@ -52,7 +52,7 @@ Wallet tool choice (avoid wrong tools):
 - Past txs: wallet_list_transactions.
 
 General rules:
-- Do as many steps as you need. Order steps so dependencies make sense; depends_on lists step ids that must complete before this step (earlier ids only).
+- Do as many steps as you need. depends_on lists step ids that must finish before this step; you may reference any step id in the plan (not only steps listed earlier in the JSON array). The runtime executes steps in dependency order.
 - Read-only research: web_search, read_file, read_memory, http_request, list_skills, read_skill, read_skill_script.
 - Mutating filesystem: write_file, run_command (only if needed).
 - risk: "wallet" for steps that sign and broadcast; "mutating" for writes/commands; "read_only" for searches, http GETs, wallet_erc20_balance, wallet_get_balance, wallet_list_transactions.
@@ -147,10 +147,14 @@ func (a *Agent) shouldSkipOrchestrationTrivial(text string) bool {
 }
 
 func (a *Agent) runOrchestrationPlan(ctx context.Context, msg gateway.IncomingMessage, userText string, plan *planning.OrchestrationPlan, contextPrefix []openai.ChatCompletionMessage) (string, error) {
+	orderedSteps, err := planning.OrchestrationExecutionOrder(plan.Steps)
+	if err != nil {
+		return "", err
+	}
 	stepOut := make(map[string]string)
 	llmRoundSeq := 0
 
-	for stepIdx, st := range plan.Steps {
+	for stepIdx, st := range orderedSteps {
 		var prior strings.Builder
 		for _, dep := range st.DependsOn {
 			if out, ok := stepOut[dep]; ok && out != "" {
@@ -307,7 +311,7 @@ func (a *Agent) runOrchestrationPlan(ctx context.Context, msg gateway.IncomingMe
 
 	// Final synthesis
 	var syn strings.Builder
-	for _, st := range plan.Steps {
+	for _, st := range orderedSteps {
 		if o, ok := stepOut[st.ID]; ok {
 			syn.WriteString("### ")
 			syn.WriteString(st.ID)

--- a/agent/orchestration_run.go
+++ b/agent/orchestration_run.go
@@ -93,6 +93,8 @@ If the task is a single trivial chat with no tools, output: {"goal":"","steps":[
 		return "", false
 	}
 
+	plan = a.lintOrchestrationPlanAllowedTools(ctx, plan, userText, contextPrefix)
+
 	for _, s := range plan.Steps {
 		log.Printf("[orchestration] planner step %s allowed_tools=%v risk=%s", s.ID, s.AllowedTools, s.Risk)
 	}

--- a/agent/planning/orchestration.go
+++ b/agent/planning/orchestration.go
@@ -36,7 +36,7 @@ const (
 	MaxOrchestrationSteps = 12
 )
 
-// ValidateOrchestrationPlan checks structure, depends_on DAG, and tool names.
+// ValidateOrchestrationPlan checks structure, depends_on DAG (acyclic), and tool names.
 func ValidateOrchestrationPlan(p *OrchestrationPlan, knownTool func(string) bool) error {
 	if p == nil {
 		return fmt.Errorf("plan is nil")
@@ -77,22 +77,82 @@ func ValidateOrchestrationPlan(p *OrchestrationPlan, knownTool func(string) bool
 			}
 		}
 	}
-	// Cycle check + forward refs only (depends must appear earlier in list for simplicity)
-	indexOf := make(map[string]int)
-	for i, s := range p.Steps {
-		indexOf[s.ID] = i
-	}
-	for _, s := range p.Steps {
-		for _, d := range s.DependsOn {
-			if !ids[d] {
-				return fmt.Errorf("step %s depends on unknown id %q", s.ID, d)
-			}
-			if indexOf[d] >= indexOf[s.ID] {
-				return fmt.Errorf("step %s: depends_on %q must refer to an earlier step", s.ID, d)
-			}
-		}
+	if _, err := OrchestrationExecutionOrder(p.Steps); err != nil {
+		return err
 	}
 	return nil
+}
+
+// OrchestrationExecutionOrder returns the same steps in a valid topological order (dependencies
+// before dependents). When several steps are ready (in-degree 0), the one with the lower
+// original index in the input slice is chosen first. Unknown step ids in depends_on, duplicate
+// step ids, empty ids, or a cycle produce an error.
+func OrchestrationExecutionOrder(steps []OrchestrationStep) ([]OrchestrationStep, error) {
+	if len(steps) == 0 {
+		return nil, fmt.Errorf("no steps")
+	}
+	idToIndex := make(map[string]int, len(steps))
+	for i, s := range steps {
+		if strings.TrimSpace(s.ID) == "" {
+			return nil, fmt.Errorf("step id is empty")
+		}
+		if _, dup := idToIndex[s.ID]; dup {
+			return nil, fmt.Errorf("duplicate step id: %s", s.ID)
+		}
+		idToIndex[s.ID] = i
+	}
+
+	inDegree := make(map[string]int, len(steps))
+	adj := make(map[string][]string, len(steps))
+	for _, s := range steps {
+		inDegree[s.ID] = 0
+	}
+	for _, s := range steps {
+		seenDep := make(map[string]bool)
+		for _, d := range s.DependsOn {
+			d = strings.TrimSpace(d)
+			if d == "" {
+				return nil, fmt.Errorf("step %s: empty depends_on", s.ID)
+			}
+			if _, ok := idToIndex[d]; !ok {
+				return nil, fmt.Errorf("step %s depends on unknown id %q", s.ID, d)
+			}
+			if seenDep[d] {
+				continue
+			}
+			seenDep[d] = true
+			inDegree[s.ID]++
+			adj[d] = append(adj[d], s.ID)
+		}
+	}
+
+	n := len(steps)
+	result := make([]OrchestrationStep, 0, n)
+	placed := make(map[string]bool, n)
+	for len(result) < n {
+		bestIdx := -1
+		for i, s := range steps {
+			if placed[s.ID] {
+				continue
+			}
+			if inDegree[s.ID] != 0 {
+				continue
+			}
+			if bestIdx == -1 || i < bestIdx {
+				bestIdx = i
+			}
+		}
+		if bestIdx == -1 {
+			return nil, fmt.Errorf("orchestration plan has a cyclic depends_on graph")
+		}
+		st := steps[bestIdx]
+		placed[st.ID] = true
+		result = append(result, st)
+		for _, v := range adj[st.ID] {
+			inDegree[v]--
+		}
+	}
+	return result, nil
 }
 
 // OrchestrationPlanFromJSON parses JSON and validates.

--- a/agent/planning/orchestration_test.go
+++ b/agent/planning/orchestration_test.go
@@ -30,7 +30,7 @@ func TestValidateOrchestrationPlan_CycleOrder(t *testing.T) {
 	if err := ValidateOrchestrationPlan(p, tools.IsRegisteredTool); err != nil {
 		t.Fatal(err)
 	}
-	// s1 depends on s2 (later step) — invalid
+	// s1 depends on s2 (listed later in JSON) — allowed; graph is s2 -> s1
 	p2 := &OrchestrationPlan{
 		Goal: "x",
 		Steps: []OrchestrationStep{
@@ -38,8 +38,42 @@ func TestValidateOrchestrationPlan_CycleOrder(t *testing.T) {
 			{ID: "s2", Description: "b", AllowedTools: []string{"read_file"}},
 		},
 	}
-	if err := ValidateOrchestrationPlan(p2, tools.IsRegisteredTool); err == nil {
-		t.Fatal("expected error for forward depends_on")
+	if err := ValidateOrchestrationPlan(p2, tools.IsRegisteredTool); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOrchestrationExecutionOrder_ReverseListDeps(t *testing.T) {
+	steps := []OrchestrationStep{
+		{ID: "s2", Description: "b", AllowedTools: []string{"read_file"}, DependsOn: []string{"s1"}},
+		{ID: "s1", Description: "a", AllowedTools: []string{"web_search"}},
+	}
+	if err := ValidateOrchestrationPlan(&OrchestrationPlan{Goal: "x", Steps: steps}, tools.IsRegisteredTool); err != nil {
+		t.Fatal(err)
+	}
+	ordered, err := OrchestrationExecutionOrder(steps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ordered) != 2 || ordered[0].ID != "s1" || ordered[1].ID != "s2" {
+		t.Fatalf("got %v, want s1 then s2", ordered)
+	}
+}
+
+func TestValidateOrchestrationPlan_CycleDetected(t *testing.T) {
+	p := &OrchestrationPlan{
+		Goal: "x",
+		Steps: []OrchestrationStep{
+			{ID: "s1", Description: "a", AllowedTools: []string{"web_search"}, DependsOn: []string{"s2"}},
+			{ID: "s2", Description: "b", AllowedTools: []string{"read_file"}, DependsOn: []string{"s1"}},
+		},
+	}
+	if err := ValidateOrchestrationPlan(p, tools.IsRegisteredTool); err == nil {
+		t.Fatal("expected cycle error from validation")
+	}
+	_, err := OrchestrationExecutionOrder(p.Steps)
+	if err == nil {
+		t.Fatal("expected cycle error from OrchestrationExecutionOrder")
 	}
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Topological execution**: `depends_on` forms a DAG; steps run in dependency order with stable tie-breaking by original planner index. Cycles and unknown dependency ids are rejected. JSON step order no longer has to list dependencies before dependents.
- **Post-plan lint**: After policy validation, a small-model pass suggests missing `allowed_tools` per step; suggestions are merged only if full plan + policy validation still passes (otherwise the original plan is kept).

## Tests

- `go test ./...`
- `go vet ./...`

## Notes

- Plan lint fails open on LLM/parse errors and does not add wallet tools when wallet is not configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0244a853-3454-4fec-b442-67f51921cd70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0244a853-3454-4fec-b442-67f51921cd70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

